### PR TITLE
fix: add types field to package.json

### DIFF
--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -26,6 +26,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./scss": "./src/styles.scss",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -24,6 +24,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./scss": "./src/styles.scss",

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -26,6 +26,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./scss": "./src/styles.scss",

--- a/packages/shoelace/package.json
+++ b/packages/shoelace/package.json
@@ -25,6 +25,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./scss": "./src/styles.scss",

--- a/packages/spectrum/package.json
+++ b/packages/spectrum/package.json
@@ -25,6 +25,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./scss": "./src/styles.scss",

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -25,6 +25,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+	"types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./scss": "./src/styles.scss",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,6 +8,7 @@
     "directory": "packages/types"
   },
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/wired/package.json
+++ b/packages/wired/package.json
@@ -25,6 +25,7 @@
     "url": "https://www.juliancataldo.com"
   },
   "type": "module",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": "./dist/esm/index.js",
     "./form": "./dist/esm/jsf-wired.js",


### PR DESCRIPTION
This PR makes types visible to typescript users. [Ref.](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)

This lack of visibility demoable in [the stackblitz](https://stackblitz.com/github/json-schema-form-element/examples?file=src%2Fcomponents%2FTypeScriptOnly.ts).

![image](https://github.com/json-schema-form-element/jsfe/assets/109672176/38e08281-5c1e-48b6-a9dc-34ffe227d194)
