### PR TITLE
feat: Add custom widget handler for `object`

### DIFF
--- a/packages/form/src/json-schema-form.ts
+++ b/packages/form/src/json-schema-form.ts
@@ -352,14 +352,12 @@ export class Jsf extends LitElement {
 
 	/* When user hit "Enter" while in some adequate inputs */
 	protected _handleKeydown(event: KeyboardEvent) {
-		console.log('cccccccccccccc');
 		const hasModifier =
 			event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 
 		if (event.key === 'Enter' && !hasModifier) {
 			setTimeout(() => {
 				if (!event.defaultPrevented && !event.isComposing) {
-					console.log({ event });
 					const form = this.#formRef.value!;
 					// const valid = form.reportValidity();
 					let valid = true;
@@ -398,7 +396,7 @@ export class Jsf extends LitElement {
 	#submit = () => {
 		const options: Widgets['submit'] = {
 			id: '__submit_button',
-			label: this.submitButtonLabel,
+			label: this.submitButtonText,
 		};
 		const error = 'Missing submit widget.';
 		return (
@@ -421,7 +419,6 @@ export class Jsf extends LitElement {
 				${ref(this.#formRef)}
 				part="base"
 				@submit=${(event: Event) => {
-					console.log('hey');
 					event.preventDefault();
 
 					const valid = (event.target as HTMLFormElement).reportValidity();

--- a/packages/form/src/triage/object.ts
+++ b/packages/form/src/triage/object.ts
@@ -17,6 +17,13 @@ export const fieldObject = (
 	if (typeof schema.properties !== 'object')
 		return widgets.callout?.({ id: '', message: error }) ?? html`${error}`;
 
+	const id = path.join('.');
+
+	function missing(widgetName: string) {
+		const options = { id, message: `Missing ${widgetName} widget.` };
+		return widgets?.callout?.(options) ?? html`<p>${options.message}</p>`;
+	}
+
 	const children = Object.entries(schema.properties).map(
 		([propName, propValue]) => {
 			if (Array.isArray(propValue) || typeof propValue === 'boolean')
@@ -59,12 +66,17 @@ export const fieldObject = (
 	if (typeof uiSchema?.['ui:title'] === 'string') label = uiSchema['ui:title'];
 
 	const options = {
-		id: path.join('.'),
+		id,
 		label,
 		helpText: schema.description,
 		children,
 		level,
 	};
+
+	if (typeof uiSchema?.['ui:widget'] === 'string') {
+		const customWidgetName = uiSchema?.['ui:widget'];
+		return widgets?.[customWidgetName]?.(options) || missing(customWidgetName);
+	}
 
 	return (
 		widgets?.object?.(options) ??

--- a/packages/form/src/triage/primitive.ts
+++ b/packages/form/src/triage/primitive.ts
@@ -189,7 +189,7 @@ export const fieldPrimitive = (
 		if (typeof uiOptions?.['ui:widget'] === 'string') {
 			const customWidgetName = uiOptions?.['ui:widget'];
 			if (customWidgetName !== 'password') {
-				return widgets?.[customWidgetName]?.(options) || missing('custom');
+				return widgets?.[customWidgetName]?.(options) || missing(customWidgetName);
 			}
 		}
 


### PR DESCRIPTION
This provides the ability to add a custom widget handler for objects, avoiding the need for polymorphism in the `object` widget.

`schema.json`:
```json
{
    "title": "Extra Fields",
    "description": "An explanation of the fields below. This new container is an atonomous widget, that can have it's own styles, yet contain form fields...like a modal that displays a terms of service.",
    "properties": {
        "agree": {
            "title": "I agree",
            "description": "Checking this box indicates you agree to our terms of service.",
            "type": "boolean"
        }
    }
}
```

`uiSchema.json`:
```json
{
    "ui:widget": "dialog",
    "agree": {
        "ui:widget": "checkbox"
    }
}
```

Then you assign the custom handler when you are extending your form:

`form.ts`:
```typescript
import { Jsf } from '@jsfe/form';
import { dialog } from './dialog';

export class JsfSystem extends Jsf {
    public widgets = {
        // standard widgets
        dialog,
    };
}
```

`dialog.ts`:
```typescript
import { nothing, html } from 'lit';

import type { Widgets } from '@jsfe/types';

export const object: Widgets['object'] = (options) => html`
    <div
        role="dialog"
        id=${options.id}
        part="object"
    >
        ${options.label ? html`<h2>${options.label}</h2>` : ``}
        <!-- -->
        ${options.helpText
            ? html`<p>${options.helpText}</p>`
            : nothing}
        <!--  -->
        ${options.children}
    </div>
`;
```